### PR TITLE
Update marcel gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    scholarsphere-client (0.3.0)
+    scholarsphere-client (0.4.0)
       aws-sdk-s3 (~> 1.49)
       faraday (> 0.12)
-      marcel (~> 0.3)
+      marcel (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -86,12 +86,8 @@ GEM
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    marcel (0.3.3)
-      mimemagic (~> 0.3.2)
+    marcel (1.0.1)
     method_source (1.0.0)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
     mini_portile2 (2.5.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
@@ -186,7 +182,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
     vcr (6.0.0)
-    webmock (3.12.2)
+    webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/lib/scholarsphere/client/version.rb
+++ b/lib/scholarsphere/client/version.rb
@@ -2,6 +2,6 @@
 
 module Scholarsphere
   module Client
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end

--- a/scholarsphere-client.gemspec
+++ b/scholarsphere-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk-s3', '~> 1.49'
   spec.add_dependency 'faraday', '> 0.12'
-  spec.add_dependency 'marcel', '~> 0.3'
+  spec.add_dependency 'marcel', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'niftany', '~> 0.6'


### PR DESCRIPTION
Because of recent changes to its licensing, the marcel gem is now a 1.0 status and this requires a new release of the client.