### PR TITLE
Updating depositor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The json output should look like:
 
 ## Documentation
 
-You can read the [ruby docs](https://www.rubydoc.info/github/psu-stewardship/scholarsphere-client/main) for the latest features.
+You can read the [ruby docs](https://www.rubydoc.info/github/psu-libraries/scholarsphere-client/main) for the latest features.
 
 ## Testing
 

--- a/lib/scholarsphere/client/ingest.rb
+++ b/lib/scholarsphere/client/ingest.rb
@@ -14,7 +14,7 @@ module Scholarsphere
     #     ingest = Scholarsphere::Client::Ingest.new(
     #       metadata: metadata,
     #       files: files,
-    #       depositor: depositor
+    #       depositor: 'abc123'
     #     )
     #     response = ingest.publish
     #
@@ -71,21 +71,11 @@ module Scholarsphere
     #
     # ## Depositor
     #
-    #     {
-    #       psu_id: '[Penn State Person]',
-    #       surname: '[family name]',
-    #       given_name: '[given name]',
-    #       email: 'abc123@psu.edu'
-    #     }
-    #
-    # Currently, the person identified as the depositor must have an active access account at Penn State. In most cases,
-    # the depositor will be the same person as the creator specified in the metadata; although, this is not always the
-    # case.  The depositor may be someone who is uploading on behalf of the creator and is not affiliated with the
-    # creation of the work. The depositor is *not* the client itself, either. The client is identified separately via
-    # the API token.
-    #
-    # Note that the fields are the same for both `creators_attributes` and `depositor`, so if the depositor is the same
-    # as the creator, all the values will need to be duplicated.
+    # The depositor is identified by their Penn State access id, which must be active at the time of ingest.  In most
+    # cases, the depositor will be the same person as the creator specified in the metadata; although, this is not
+    # always the case.  The depositor may be someone who is uploading on behalf of the creator and is not affiliated
+    # with the creation of the work. The depositor is *not* the client itself, either. The client is identified
+    # separately via the API token.
     #
     #
     class Ingest
@@ -93,7 +83,7 @@ module Scholarsphere
 
       # @param metadata [Hash] Metadata attributes
       # @param files [Array<File,IO,Pathnme>,Hash] An array of File or IO objects, or a hash with a :file param
-      # @param depositor [Hash] The name and access id of the depositor
+      # @param depositor [String] access id of the depositor
       # @param permissions [Hash] (optional) Additional permissions to apply to the resource
       def initialize(metadata:, files:, depositor:, permissions: {})
         @content = build_content_hash(files)

--- a/scholarsphere-client.gemspec
+++ b/scholarsphere-client.gemspec
@@ -12,12 +12,12 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Client to connect to Scholarpshere'
   spec.description   = 'Client software to create new content for the Scholarsphere repository at Penn State.'
-  spec.homepage      = 'https://github.com/psu-stewardship/scholarsphere-client'
+  spec.homepage      = 'https://github.com/psu-libraries/scholarsphere-client'
 
   spec.metadata = {
     'homepage_uri' => spec.homepage,
     'source_code_uri' => spec.homepage,
-    'documentation_uri' => 'https://www.rubydoc.info/github/psu-stewardship/scholarsphere-client/main',
+    'documentation_uri' => 'https://www.rubydoc.info/github/psu-libraries/scholarsphere-client/main',
     'allowed_push_host' => 'https://rubygems.org'
   }
 


### PR DESCRIPTION
Depositor is just a string and not a hash as the documentation was suggesting.

Fixes #31 